### PR TITLE
fixed map slider overlay issue on Trends Page

### DIFF
--- a/static/css/kStyle.css
+++ b/static/css/kStyle.css
@@ -2,15 +2,15 @@
 body { padding: 0; margin: 0; }
   
  /* set map, body, and html to 100% of the screen size */
- #map { position:absolute; top:0; bottom:0; width:100% }
+ #kMap { position:absolute; top:0; bottom:0; width:100% }
 
  .map-overlay {
     font: 12px/20px 'Helvetica Neue', Arial, Helvetica, sans-serif;
     position: absolute;
     width: 25%;
-    top: 0;
-    left: 0;
-    padding: 10px;
+    top: 75;
+    left: 25;
+    padding: 25px;
 }
 
 .map-overlay .map-overlay-inner {
@@ -40,4 +40,10 @@ body { padding: 0; margin: 0; }
     position: relative;
     margin: 0;
     cursor: ew-resize;
+}
+
+#year {
+    font-weight: 500;
+    font-size: 1.5em;
+    color: black;
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2,8 +2,6 @@
 body {
     background-color: #ededed;
     font-family: 'Roboto', sans-serif;
-    padding: 0; 
-    margin: 0;
     /* font-family: 'Merriweather', serif; */
     /* font-family: 'Bitter', serif; */
 }
@@ -32,7 +30,7 @@ body {
     padding-left: 35px;
     padding-right: 30px;
     padding-bottom: 10px;
-    border-bottom: 1px solid #c1c1c1;
+    border-bottom: 1px solid #c1c1c1;
     z-index: 3;
     /* -webkit-box-shadow: 0px 3px 15px 0px rgba(0,0,0,0.5); */
     box-shadow: 0px 3px 15px 0px rgba(0,0,0,0.5);
@@ -163,12 +161,6 @@ body {
 
 /* MAP */
 
-#kMap { 
-    position:absolute; 
-    top:0; 
-    bottom:0; 
-    width:100% }
-
 #map {
     /* index */
     margin-top: 0px;
@@ -182,7 +174,7 @@ body {
     margin-bottom: 10px;
     width: 100vw;
     height: 90vh;
-    z-index: -1;
+    z-index: 1;
 }
 
 #footer-box {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2,6 +2,8 @@
 body {
     background-color: #ededed;
     font-family: 'Roboto', sans-serif;
+    padding: 0; 
+    margin: 0;
     /* font-family: 'Merriweather', serif; */
     /* font-family: 'Bitter', serif; */
 }
@@ -161,6 +163,12 @@ body {
 
 /* MAP */
 
+#kMap { 
+    position:absolute; 
+    top:0; 
+    bottom:0; 
+    width:100% }
+
 #map {
     /* index */
     margin-top: 0px;
@@ -174,7 +182,7 @@ body {
     margin-bottom: 10px;
     width: 100vw;
     height: 90vh;
-    z-index: 1;
+    z-index: -1;
 }
 
 #footer-box {

--- a/static/js/kHeatmap.js
+++ b/static/js/kHeatmap.js
@@ -1,6 +1,6 @@
 // Initializing the map with dark theme, centered on Austin
 var map = new mapboxgl.Map({
-    container: 'map',
+    container: 'kMap',
     style: 'mapbox://styles/mapbox/dark-v9',
     center: [-97.7431,30.2672],
     zoom: 9.55,

--- a/templates/trends.html
+++ b/templates/trends.html
@@ -10,20 +10,36 @@
   <link href='https://api.mapbox.com/mapbox-gl-js/v0.51.0/mapbox-gl.css' rel='stylesheet' />
   <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.51.0/mapbox-gl.css' rel='stylesheet' />
   <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.51.0/mapbox-gl.js'></script>
+  <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script> 
 
   <!-- Our CSS -->
+  <link rel="stylesheet" type="text/css" href="../static/css/style.css">
   <link rel="stylesheet" type="text/css" href="../static/css/kStyle.css">
+
+  <!--D3 cdn-->
+  <script src="https://d3js.org/d3.v4.min.js"></script>
+
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.2/css/bootstrap.min.css" integrity="sha384-PsH8R72JQ3SOdhVi3uxftmaW6Vc51MKb0q5P2rRUpPvrszuE4W1povHYgTpBfshb"
+  crossorigin="anonymous">
 </head>
 
 <body>
     {% include "navbar.html" %}
   <!-- The div where we will inject our map -->
-  <div id="map"></div>
+  <div id="kMap"></div>
 
   <!-- API key -->
   <script type="text/javascript" src="../static/js/kConfig.js"></script>
+
   <!-- JS -->
   <script type="text/javascript" src="../static/js/kHeatmap.js"></script>
+
+  <div class='map-overlay top'>
+    <div class='map-overlay-inner'>
+        <label id='year'></label>
+        <input id='slider' type='range' min='1898' max='2018' step='1' value='0' />
+    </div>
+  </div>
 </body>
 
 <!-- FOOTER -->


### PR DESCRIPTION
Both the Explore Page and the Trends Page used different parameters for the same ID of 'map'. For the Trends page, I changed the 'map' ID used to a new and unique ID called 'kMap'. This fixed the issue of the input slider overlay not showing up on the timelapse map.